### PR TITLE
Fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Installation
 
 ### [Fisherman](https://github.com/fisherman/fisherman)
 
-    fisher install akhilman/fish-prompt-hline
+    fisher add akhilman/fish-prompt-hline
 
 Then restart fish or call `$ . ~/.config/fish/conf.d/prompt_hline_init.fish`


### PR DESCRIPTION
Maybe fisher has updated, but `fisher install` doesn't work for me, and `fisher add` does.

```
usage: fisher add <package...>     Add packages
       fisher rm  <package...>     Remove packages
       fisher                      Update all packages
       fisher ls  [<regex>]        List installed packages matching <regex>
       fisher --help               Show this help
       fisher --version            Show the current version
       fisher self-update          Update to the latest version
       fisher self-uninstall       Uninstall from your system
examples:
       fisher add jethrokuan/z rafaelrinaldi/pure
       fisher add gitlab.com/foo/bar@v2
       fisher add ~/path/to/local/pkg
       fisher add <file
       fisher rm rafaelrinaldi/pure
       fisher ls | fisher rm
       fisher ls fish-\*
```